### PR TITLE
Fix flakey `description_cannot_be_longer_than_3000_chars` tests

### DIFF
--- a/jira-wip/src/koans/01_ticket/03_validation.rs
+++ b/jira-wip/src/koans/01_ticket/03_validation.rs
@@ -63,7 +63,7 @@ mod validation {
         #[test]
         #[should_panic]
         fn description_cannot_be_longer_than_3000_chars() {
-            let description = (3000..10_000).fake();
+            let description = (3001..10_000).fake();
             let title = (0..50).fake();
 
             create_ticket(title, description, Status::ToDo);

--- a/jira-wip/src/koans/02_ticket_store/06_results.rs
+++ b/jira-wip/src/koans/02_ticket_store/06_results.rs
@@ -182,7 +182,7 @@ mod result {
 
         #[test]
         fn description_cannot_be_longer_than_3000_chars() {
-            let description = (3000..10_000).fake();
+            let description = (3001..10_000).fake();
             let title = (0..50).fake();
 
             let result = TicketDraft::new(title, description, Status::ToDo);

--- a/jira-wip/src/koans/02_ticket_store/07_vec.rs
+++ b/jira-wip/src/koans/02_ticket_store/07_vec.rs
@@ -180,7 +180,7 @@ mod vec {
 
         #[test]
         fn description_cannot_be_longer_than_3000_chars() {
-            let description = (3000..10_000).fake();
+            let description = (3001..10_000).fake();
             let title = (0..50).fake();
 
             let result = TicketDraft::new(title, description, Status::ToDo);

--- a/jira-wip/src/koans/02_ticket_store/08_delete_and_update.rs
+++ b/jira-wip/src/koans/02_ticket_store/08_delete_and_update.rs
@@ -311,7 +311,7 @@ mod delete_and_update {
 
         #[test]
         fn description_cannot_be_longer_than_3000_chars() {
-            let description = (3000..10_000).fake();
+            let description = (3001..10_000).fake();
 
             assert!(TicketDescription::new(description).is_err())
         }


### PR DESCRIPTION
The test would previously generate a string between 3000 and 10,000 characters. Which meant if you were unlucky, it would fail! 

This PR changes the range to 3001 to 10,000. 

Fixes the final point in #18 