### PR TITLE
Typo

### DIFF
--- a/jira-wip/src/koans/01_ticket/02_status.rs
+++ b/jira-wip/src/koans/01_ticket/02_status.rs
@@ -57,7 +57,7 @@ mod status {
                 // If we want to take the same action for multiple variants, we can use a | to list them.
                 // Variant | Variant | ... | Variant => Expression
                 //
-                // We are panicing in this case, thus making the test fail if this branch of our match
+                // We are panicking in this case, thus making the test fail if this branch of our match
                 // statement gets executed.
                 Status::ToDo | Status::InProgress | Status::Done => panic!("The ticket is not blocked!")
             }

--- a/jira-wip/src/koans/01_ticket/06_traits.rs
+++ b/jira-wip/src/koans/01_ticket/06_traits.rs
@@ -31,7 +31,7 @@ mod traits {
     /// }
     /// ```
     ///
-    /// In pratical terms, a trait defines the signature of a collection of methods.
+    /// In practical terms, a trait defines the signature of a collection of methods.
     /// To implement a trait, a struct or an enum have to implement those methods
     /// in `impl Trait` block:
     /// 


### PR DESCRIPTION
Also 
```rust
    pub struct Status {
```
should be an `enum`. Is that inserted there on purpose?