### PR TITLE
Fake title shouldn't be empty

### DIFF
--- a/jira-wip/src/koans/01_ticket/03_validation.rs
+++ b/jira-wip/src/koans/01_ticket/03_validation.rs
@@ -25,7 +25,7 @@ mod validation {
     /// We will learn a better way to handle recoverable errors such as this one further along,
     /// but let's rely on panic for the time being.
     fn create_ticket(title: String, description: String, status: Status) -> Ticket {
-       todo!()
+        todo!()
     }
 
     #[cfg(test)]
@@ -67,7 +67,7 @@ mod validation {
         #[should_panic]
         fn description_cannot_be_longer_than_3000_chars() {
             let description = (3001..10_000).fake();
-            let title = (0..50).fake();
+            let title = (1..50).fake();
 
             create_ticket(title, description, Status::ToDo);
         }
@@ -75,7 +75,7 @@ mod validation {
         #[test]
         fn valid_tickets_can_be_created() {
             let description = (0..3000).fake();
-            let title = (0..50).fake();
+            let title = (1..50).fake();
             let status = Status::Done;
 
             create_ticket(title, description, status);

--- a/jira-wip/src/koans/02_ticket_store/06_result.rs
+++ b/jira-wip/src/koans/02_ticket_store/06_result.rs
@@ -189,7 +189,7 @@ mod result {
         #[test]
         fn description_cannot_be_longer_than_3000_chars() {
             let description = (3001..10_000).fake();
-            let title = (0..50).fake();
+            let title = (1..50).fake();
 
             let result = TicketDraft::new(title, description);
             assert!(result.is_err())

--- a/jira-wip/src/koans/02_ticket_store/07_vec.rs
+++ b/jira-wip/src/koans/02_ticket_store/07_vec.rs
@@ -44,7 +44,7 @@ mod vec {
         /// The Rust documentation for `HashMap` will also be handy:
         /// https://doc.rust-lang.org/std/collections/struct.HashMap.html
         pub fn list(&self) -> Vec<&Ticket> {
-           todo!()
+            todo!()
         }
 
         fn generate_id(&mut self) -> TicketId {
@@ -187,7 +187,7 @@ mod vec {
         #[test]
         fn description_cannot_be_longer_than_3000_chars() {
             let description = (3001..10_000).fake();
-            let title = (0..50).fake();
+            let title = (1..50).fake();
 
             let result = TicketDraft::new(title, description);
             assert!(result.is_err())


### PR DESCRIPTION
I noticed certain tests were flaky and they were caused by fake titles being empty occasionally. This PR excludes 0 when generating fake titles.