### PR TITLE
Remove unused ValidationError constructor

### DIFF
--- a/jira-wip/src/koans/02_ticket_store/06_result.rs
+++ b/jira-wip/src/koans/02_ticket_store/06_result.rs
@@ -78,12 +78,6 @@ mod result {
     #[derive(PartialEq, Debug, Clone)]
     pub struct ValidationError(String);
 
-    impl ValidationError {
-        fn new(msg: &str) -> Self {
-            Self(msg.to_string())
-        }
-    }
-
     /// To use `ValidationError` as the `Err` variant in a `Result` we need to implement
     /// the `Error` trait.
     ///

--- a/jira-wip/src/koans/02_ticket_store/07_vec.rs
+++ b/jira-wip/src/koans/02_ticket_store/07_vec.rs
@@ -90,12 +90,6 @@ mod vec {
     #[derive(PartialEq, Debug, Clone)]
     pub struct ValidationError(String);
 
-    impl ValidationError {
-        fn new(msg: &str) -> Self {
-            Self(msg.to_string())
-        }
-    }
-
     impl Error for ValidationError {}
 
     impl std::fmt::Display for ValidationError {

--- a/jira-wip/src/koans/02_ticket_store/08_delete_and_update.rs
+++ b/jira-wip/src/koans/02_ticket_store/08_delete_and_update.rs
@@ -161,12 +161,6 @@ mod delete_and_update {
     #[derive(PartialEq, Debug, Clone)]
     pub struct ValidationError(String);
 
-    impl ValidationError {
-        fn new(msg: &str) -> Self {
-            Self(msg.to_string())
-        }
-    }
-
     impl Error for ValidationError {}
 
     impl std::fmt::Display for ValidationError {

--- a/jira-wip/src/koans/02_ticket_store/09_store_recap.rs
+++ b/jira-wip/src/koans/02_ticket_store/09_store_recap.rs
@@ -145,12 +145,6 @@ pub mod store_recap {
     #[derive(PartialEq, Debug, Clone)]
     pub struct ValidationError(String);
 
-    impl ValidationError {
-        fn new(msg: &str) -> Self {
-            Self(msg.to_string())
-        }
-    }
-
     impl Error for ValidationError {}
 
     impl std::fmt::Display for ValidationError {


### PR DESCRIPTION
It looks like this constructor is not being used anywhere, since all the `ValidationError`s are created directly from the struct. It might be confusing for Rust beginners like me, so unless there is a good reason to keep it around, I suggest it should be removed :slightly_smiling_face: 